### PR TITLE
fix: correct library path to published packages

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,6 +1,7 @@
 import {join} from 'node:path';
+import {fileURLToPath} from "url";
 import {type Library, type FFIFunction, dlopen} from 'bun:ffi';
-import { getConfigFromPkgJson } from './config';
+import {getConfigFromPkgJson} from './config';
 
 if (typeof Bun === "undefined") {
   throw new Error("This script must be run with Bun.");
@@ -151,7 +152,7 @@ export async function getLibraryPaths(
     // published package
     const packageTarget = await getTarget(platform, arch);
     const fullPackageName = `${packageName}-${packageTarget}`;
-    const publishedPath = join(import.meta.resolve(fullPackageName), libraryName);
+    const publishedPath = fileURLToPath(import.meta.resolve(fullPackageName));
     if (await Bun.file(publishedPath).exists()) {
       paths.push(publishedPath);
     }


### PR DESCRIPTION
**Motivation**
- when testing https://github.com/ChainSafe/blst-z/actions/runs/15106924168/job/42457650340 I was not able to load a published package
- the resolve library path is something like `blst-z/bun/node_modules/@chainsafe/blst-bun-darwin-arm64/libblst_min_pk.dylib/libblst_min_pk.dylib`

**Description**
- no need to append library name again
- wrap with `fileURLToPath` to strip `file://` prefix
- was able to test in my local environment