### PR TITLE
fix: windows library suffix

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -94,7 +94,7 @@ export function getLibrarySuffix(platform: NodeJS.Platform): string {
     case 'darwin':
       return '.dylib';
     case 'win32':
-      return '.dll';
+      return '.lib';
     default:
       return '.so';
   }


### PR DESCRIPTION
- see https://github.com/ChainSafe/lodestar-bun/actions/runs/18100859450/job/51503160376?pr=12
- > lodestar_z_bun.lib